### PR TITLE
Update name postfixes

### DIFF
--- a/data/102/026/785/102026785.geojson
+++ b/data/102/026/785/102026785.geojson
@@ -47,6 +47,9 @@
         "\u03a4\u03b1\u03ca\u03c4\u03bf\u03cd\u03bd\u03b3\u03ba"
     ],
     "name:eng_x_preferred":[
+        "Taitung"
+    ],
+    "name:eng_x_variant":[
         "Taitung City"
     ],
     "name:epo_x_preferred":[
@@ -180,8 +183,8 @@
     "wof:belongsto":[
         102191569,
         85632403,
-        85679623,
-        1108808557
+        1108808557,
+        85679623
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -209,8 +212,8 @@
         }
     ],
     "wof:id":102026785,
-    "wof:lastmodified":1690875920,
-    "wof:name":"Taitung City",
+    "wof:lastmodified":1730271679,
+    "wof:name":"Taitung",
     "wof:parent_id":85679623,
     "wof:placetype":"locality",
     "wof:population":109584,

--- a/data/124/287/600/9/1242876009.geojson
+++ b/data/124/287/600/9/1242876009.geojson
@@ -32,19 +32,25 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Sindian"
+    ],
+    "name:eng_x_variant":[
+        "Sindian City"
+    ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191569,
         85632403,
-        85679585,
-        1108808549
+        1108808549,
+        85679585
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":6692747
     },
     "wof:country":"TW",
-    "wof:geomhash":"3d2e846dea9f0ddffdf5e6067187a117",
+    "wof:geomhash":"f4c0c4c13c9de38289cc78429e2fba91",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -55,8 +61,8 @@
         }
     ],
     "wof:id":1242876009,
-    "wof:lastmodified":1566589888,
-    "wof:name":"Sindian City",
+    "wof:lastmodified":1730271683,
+    "wof:name":"Sindian",
     "wof:parent_id":85679585,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-tw",
@@ -66,9 +72,9 @@
 },
   "bbox": [
     121.53111,
-    24.94062000000001,
+    24.94062,
     121.53111,
-    24.94062000000001
+    24.94062
 ],
-  "geometry": {"coordinates":[121.53111,24.94062000000001],"type":"Point"}
+  "geometry": {"coordinates":[121.53111,24.94062],"type":"Point"}
 }

--- a/data/890/467/709/890467709.geojson
+++ b/data/890/467/709/890467709.geojson
@@ -23,6 +23,10 @@
         "Xinyi"
     ],
     "name:eng_x_preferred":[
+        "Sinyi"
+    ],
+    "name:eng_x_variant":[
+        "Sinyi District",
         "Xinyi District"
     ],
     "name:hak_x_preferred":[
@@ -67,8 +71,8 @@
     "wof:belongsto":[
         102191569,
         85632403,
-        85679583,
-        1108808545
+        1108808545,
+        85679583
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -90,8 +94,8 @@
         }
     ],
     "wof:id":890467709,
-    "wof:lastmodified":1566589756,
-    "wof:name":"Sinyi District",
+    "wof:lastmodified":1730095153,
+    "wof:name":"Sinyi",
     "wof:parent_id":85679583,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/468/269/890468269.geojson
+++ b/data/890/468/269/890468269.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Da\u2019an"
+    ],
+    "name:eng_x_variant":[
+        "Da\u2019an District"
+    ],
     "name:hak_x_preferred":[
         "Thai-\u00f4n-kh\u00ee"
     ],
@@ -48,8 +54,8 @@
     "wof:belongsto":[
         102191569,
         85632403,
-        85679583,
-        1108808545
+        1108808545,
+        85679583
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -70,8 +76,8 @@
         }
     ],
     "wof:id":890468269,
-    "wof:lastmodified":1566589822,
-    "wof:name":"Da\u2019an District",
+    "wof:lastmodified":1730095153,
+    "wof:name":"Da\u2019an",
     "wof:parent_id":85679583,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/468/693/890468693.geojson
+++ b/data/890/468/693/890468693.geojson
@@ -25,6 +25,12 @@
     "name:deu_x_preferred":[
         "Songshan"
     ],
+    "name:eng_x_preferred":[
+        "Songshan"
+    ],
+    "name:eng_x_variant":[
+        "Songshan District"
+    ],
     "name:fra_x_preferred":[
         "Songshan"
     ],
@@ -52,8 +58,8 @@
     "wof:belongsto":[
         102191569,
         85632403,
-        85679583,
-        1108808545
+        1108808545,
+        85679583
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -74,8 +80,8 @@
         }
     ],
     "wof:id":890468693,
-    "wof:lastmodified":1566589820,
-    "wof:name":"Songshan District",
+    "wof:lastmodified":1730095153,
+    "wof:name":"Songshan",
     "wof:parent_id":85679583,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/468/749/890468749.geojson
+++ b/data/890/468/749/890468749.geojson
@@ -25,6 +25,12 @@
     "name:deu_x_preferred":[
         "Nangang"
     ],
+    "name:eng_x_preferred":[
+        "Nangang"
+    ],
+    "name:eng_x_variant":[
+        "Nangang District"
+    ],
     "name:eus_x_preferred":[
         "Nangang"
     ],
@@ -61,8 +67,8 @@
     "wof:belongsto":[
         102191569,
         85632403,
-        85679583,
-        1108808545
+        1108808545,
+        85679583
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -83,8 +89,8 @@
         }
     ],
     "wof:id":890468749,
-    "wof:lastmodified":1566589825,
-    "wof:name":"Nangang District",
+    "wof:lastmodified":1730095153,
+    "wof:name":"Nangang",
     "wof:parent_id":85679583,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/468/761/890468761.geojson
+++ b/data/890/468/761/890468761.geojson
@@ -41,6 +41,9 @@
         "Hualien"
     ],
     "name:eng_x_preferred":[
+        "Hualien"
+    ],
+    "name:eng_x_variant":[
         "Hualien City"
     ],
     "name:epo_x_preferred":[
@@ -172,8 +175,8 @@
     "wof:belongsto":[
         102191569,
         85632403,
-        85679607,
-        1108808557
+        1108808557,
+        85679607
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -195,8 +198,8 @@
         }
     ],
     "wof:id":890468761,
-    "wof:lastmodified":1690876018,
-    "wof:name":"Hualien City",
+    "wof:lastmodified":1730271683,
+    "wof:name":"Hualien",
     "wof:parent_id":85679607,
     "wof:placetype":"localadmin",
     "wof:population":0,

--- a/data/890/472/077/890472077.geojson
+++ b/data/890/472/077/890472077.geojson
@@ -32,6 +32,10 @@
         "Makung"
     ],
     "name:eng_x_preferred":[
+        "Ma"
+    ],
+    "name:eng_x_variant":[
+        "Ma-kung",
         "Magong"
     ],
     "name:fas_x_preferred":[
@@ -195,8 +199,8 @@
     "wof:belongsto":[
         102191569,
         85632403,
-        85679627,
-        1108808557
+        1108808557,
+        85679627
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -218,8 +222,8 @@
         }
     ],
     "wof:id":890472077,
-    "wof:lastmodified":1690875983,
-    "wof:name":"Ma-kung",
+    "wof:lastmodified":1730095153,
+    "wof:name":"Ma",
     "wof:parent_id":85679627,
     "wof:placetype":"locality",
     "wof:population":56435,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2207.

This PR updates name properties for names with certain postfixes. The `wof:name` property and English preferred name values were updated to remove postfixes, and English variant names were adjusted/added to store the name with the postfix. Label properties were also updated, when present. No PIP work needed, property edits only.

Number of records updated: 8